### PR TITLE
Fix relative import error by adding package initializer

### DIFF
--- a/mybot/__init__.py
+++ b/mybot/__init__.py
@@ -1,0 +1,1 @@
+# Initialize package


### PR DESCRIPTION
## Summary
- add `mybot/__init__.py` to mark mybot as a package

## Testing
- `python -m py_compile mybot/bot.py`


------
https://chatgpt.com/codex/tasks/task_e_685dc7ada4388329b850081c3b5bfbe9