### PR TITLE
Fix indentation error in mission_service

### DIFF
--- a/mybot/services/mission_service.py
+++ b/mybot/services/mission_service.py
@@ -302,8 +302,8 @@ class MissionService:
                 record.completed_at = datetime.datetime.utcnow()
                 await self.point_service.add_points(user_id, mission.reward_points, bot=bot)
                 if bot:
-                    from ..utils.message_utils import get_mission_completed_message
-from ..utils.keyboard_utils import get_mission_completed_keyboardd
+                    from utils.message_utils import get_mission_completed_message
+                    from utils.keyboard_utils import get_mission_completed_keyboard
 
                     text = await get_mission_completed_message(mission)
                     await bot.send_message(


### PR DESCRIPTION
## Summary
- correct indentation in `update_progress` for sending mission completion messages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_685dcfce1b088329a08189bb5c24b64f