### PR TITLE
Fix imports that used `mybot` prefix

### DIFF
--- a/mybot/handlers/backpack_handler.py
+++ b/mybot/handlers/backpack_handler.py
@@ -6,8 +6,8 @@ from aiogram import Router, F
 from aiogram.types import Message, CallbackQuery, InlineKeyboardMarkup, InlineKeyboardButton
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from mybot.services.backpack_service import BackpackService
-from mybot.utils.user_roles import get_user_role
+from services.backpack_service import BackpackService
+from utils.user_roles import get_user_role
 
 router = Router()
 

--- a/mybot/services/backpack_service.py
+++ b/mybot/services/backpack_service.py
@@ -5,8 +5,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
 
-from mybot.models.backpack_item import BackpackItem
-from mybot.models.pista import Pista
+from models.backpack_item import BackpackItem
+from models.pista import Pista
 
 logger = logging.getLogger(__name__)
 

--- a/mybot/services/mission_service.py
+++ b/mybot/services/mission_service.py
@@ -156,7 +156,7 @@ class MissionService:
             unlock_pista = mission.action_data.get("unlocks_pista")
         
         if unlock_pista:
-            from mybot.services.backpack_service import BackpackService
+            from services.backpack_service import BackpackService
             backpack_service = BackpackService(self.session)
             pista = await backpack_service.get_pista_by_title(unlock_pista)
             if pista:
@@ -302,8 +302,8 @@ class MissionService:
                 record.completed_at = datetime.datetime.utcnow()
                 await self.point_service.add_points(user_id, mission.reward_points, bot=bot)
                 if bot:
-                    from ..utils.message_utils import get_mission_completed_message
-from ..utils.keyboard_utils import get_mission_completed_keyboardd
+                    from utils.message_utils import get_mission_completed_message
+                    from utils.keyboard_utils import get_mission_completed_keyboard
 
                     text = await get_mission_completed_message(mission)
                     await bot.send_message(


### PR DESCRIPTION
## Summary
- update handler and services to avoid `mybot.` prefix so `python mybot/bot.py` works

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_685dcfce1b088329a08189bb5c24b64f