### PR TITLE
Fix import path in bot.py

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -5,7 +5,7 @@ from aiogram.enums.parse_mode import ParseMode
 from aiogram.client.bot import DefaultBotProperties
 from aiogram.fsm.storage.memory import MemoryStorage
 
-from .database.setup import init_db, get_session
+from database.setup import init_db, get_session
 
 from .handlers import start, free_user
 from .handlers import daily_gift, minigames


### PR DESCRIPTION
## Summary
- update bot import to use absolute path for database setup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685dde688ff883298f372f7b5ce1e508