### PR TITLE
Fix menu_factory import error

### DIFF
--- a/mybot/utils/menu_factory.py
+++ b/mybot/utils/menu_factory.py
@@ -189,3 +189,5 @@ class MenuFactory:
                 "El estado de configuración solicitado no es válido.",
                 get_setup_confirmation_kb("cancel_setup")
             )
+# Global factory instance
+menu_factory = MenuFactory()


### PR DESCRIPTION
## Summary
- restore `menu_factory` global instance in `menu_factory.py`

## Testing
- `python -m py_compile mybot/utils/menu_factory.py`

------
https://chatgpt.com/codex/tasks/task_e_685defd3633c8329821506f5a0c049f5