### PR TITLE
Update admin mission creation flow

### DIFF
--- a/mybot/bot.py
+++ b/mybot/bot.py
@@ -5,7 +5,7 @@ from aiogram.enums.parse_mode import ParseMode
 from aiogram.client.bot import DefaultBotProperties
 from aiogram.fsm.storage.memory import MemoryStorage
 
-from database.setup import init_db, get_session
+from mybot.database import init_db, get_session, test_connection
 
 from handlers import start, free_user
 from handlers import daily_gift, minigames
@@ -33,8 +33,17 @@ from services import (
 from services.scheduler import auction_monitor_scheduler, free_channel_cleanup_scheduler
 
 
+async def startup() -> None:
+    if await test_connection():
+        print("✅ Conexión a base de datos exitosa")
+        await init_db()
+    else:
+        print("❌ Error de conexión a base de datos")
+        exit(1)
+
+
 async def main() -> None:
-    await init_db()
+    await startup()
     Session = await get_session()
 
     logging.basicConfig(level=logging.INFO)

--- a/mybot/database/__init__.py
+++ b/mybot/database/__init__.py
@@ -1,0 +1,9 @@
+from .setup import init_db, get_session, get_async_session, test_connection
+
+__all__ = [
+    "init_db",
+    "get_session",
+    "get_async_session",
+    "test_connection",
+]
+

--- a/mybot/database/setup.py
+++ b/mybot/database/setup.py
@@ -22,3 +22,25 @@ async def get_session() -> async_sessionmaker[AsyncSession]:
         raise RuntimeError("Database engine not initialized. Call init_db() first.")
     async_session = async_sessionmaker(bind=_engine, class_=AsyncSession, expire_on_commit=False)
     return async_session
+
+# Simple session factory returning AsyncSession directly
+
+def get_async_session() -> AsyncSession:
+    """Return a new AsyncSession using the current engine."""
+    if _engine is None:
+        raise RuntimeError("Database engine not initialized. Call init_db() first.")
+    session_factory = async_sessionmaker(bind=_engine, class_=AsyncSession, expire_on_commit=False)
+    return session_factory()
+
+
+async def test_connection() -> bool:
+    """Check database connectivity."""
+    try:
+        engine = create_async_engine(Config.DATABASE_URL, echo=False, poolclass=NullPool)
+        async with engine.connect() as conn:
+            await conn.execute("SELECT 1")
+        await engine.dispose()
+        return True
+    except Exception:
+        return False
+


### PR DESCRIPTION
## Summary
- add session helper and connection test in database module
- replace mission duration handler with simplified version
- update bot startup to test database connection

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685e02e6f5d483298b377b427c49eb37